### PR TITLE
Support for Laravel ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
 	],
 	"require": {
 		"php": "^7.2",
-		"illuminate/console": "^6.0|^7.0",
-		"illuminate/support": "^6.0|^7.0"
+		"illuminate/console": "^6.0|^7.0|^8.0",
+		"illuminate/support": "^6.0|^7.0|^8.0"
 	},
 	"require-dev": {
 		"orchestra/testbench": "^4.0"


### PR DESCRIPTION
Tests are passing, default stub should still work as intended.